### PR TITLE
Fix version tag commit not being pushed on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,18 +21,22 @@ jobs:
     name: Publish Package
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
             ref: master
-            fetch-depth: 1
+            fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: 24
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Install Packages
         run: npm i --ignore-scripts
       - name: Run Tests
@@ -40,4 +44,4 @@ jobs:
       - name: Audit Signatures
         run: npm audit signatures
       - name: Publish Package
-        run: npx lerna publish ${{ github.event.inputs.release-type }} --force-publish -y --push=false --gitTagVersion=false
+        run: npx lerna publish ${{ github.event.inputs.release-type }} --force-publish -y


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure that version tags are committed and pushed when publishing the package. The changes address the issues identified in the previous setup:

- **Permissions**: Changed job permissions from `contents: read` to `contents: write` to allow pushing commits and tags.
- **Checkout Depth**: Updated the checkout depth from `fetch-depth: 1` to `fetch-depth: 0` to ensure the full history is available for lerna to detect tags.
- **Git Identity**: Added a step to configure the git identity for the `github-actions[bot]`, enabling it to create commits and tags.
- **Lerna Flags**: Removed the `--push=false --gitTagVersion=false` flags, allowing lerna to create and push version commits and tags.

These changes resolve the issue of being unable to publish new versions due to missing tags and commits.