### PR TITLE
Fix version tag commit and PR flow in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
-            ref: ${{ github.ref }}
+            ref: master
             fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,12 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
-            ref: master
+            ref: ${{ github.ref }}
             fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
@@ -43,5 +44,16 @@ jobs:
         run: npm test
       - name: Audit Signatures
         run: npm audit signatures
+      - name: Bump Versions
+        run: npx lerna version ${{ github.event.inputs.release-type }} --force-publish -y --no-push --no-git-tag-version
       - name: Publish Package
-        run: npx lerna publish ${{ github.event.inputs.release-type }} --force-publish -y
+        run: npx lerna publish from-package -y
+      - name: Create Release Pull Request
+        uses: peter-evans/create-pull-request@6fd39f654f95dd1c59468f02dd6577d98589b7f8 # 7.0.8
+        with:
+          branch: chore/release-${{ github.run_id }}
+          base: master
+          title: "Release: publish ${{ github.event.inputs.release-type }}"
+          commit-message: "Updates versions after publish"
+          body: |
+            This PR captures version bumps generated during the publish workflow.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Audit Signatures
         run: npm audit signatures
       - name: Bump Versions
-        run: npx lerna version ${{ github.event.inputs.release-type }} --force-publish -y --no-push --no-git-tag-version
+        run: npx lerna version ${{ github.event.inputs.release-type }} --force-publish -y --no-push
       - name: Publish Package
         run: npx lerna publish from-package -y
       - name: Create Release Pull Request


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing the package to ensure version tags are committed correctly and to comply with branch protection rules. The following changes were made:

- Changed job permissions from `contents: read` to `contents: write` to allow pushing commits and tags.
- Updated checkout depth from `fetch-depth: 1` to `fetch-depth: 0` to ensure full history is available for tag detection.
- Added a step to configure git identity for the `github-actions[bot]`.
- Removed flags `--push=false --gitTagVersion=false` from lerna commands to enable version tagging and pushing.
- Implemented a PR-safe release flow that:
  - Bumps versions locally without direct push.
  - Publishes the bumped versions.
  - Creates a pull request with version bump commits.
- Added `pull-requests: write` permission to allow the workflow to create pull requests.
- Updated the checkout reference to use the triggering branch instead of hardcoded `master`.

These changes address the issues of version tagging and the requirement for pull requests when publishing.